### PR TITLE
bug-fix: make sure the custom data path existed

### DIFF
--- a/tasks/setup-redhat.yml
+++ b/tasks/setup-redhat.yml
@@ -21,6 +21,14 @@
     group=root
     mode=0644
 
+- name: create postgresql data path
+  file: >-
+    path={{ postgresql_data_directory }}
+    state=directory
+    owner=postgres
+    group=postgres
+    mode=0700
+
 - name: initialize postgresql if necessary
   command: >-
     creates={{ postgresql_data_directory }}/PG_VERSION


### PR DESCRIPTION
When I tried to use a custom data directory, which is mentioned in user guide:

> postgresql_data_directory: Path to the PostgreSQL data directory, aka PGDATA on Red Hat. Defaults to /var/lib/pgsql/data.

I got an error like below:

`fatal: [pg-test]: FAILED! => {"changed": true, "cmd": ["/usr/bin/postgresql-setup", "initdb"], "delta": "0:00:00.020728", "end": "2016-07-12 22:13:21.633933", "failed": true, "rc": 1, "start": "2016-07-12 22:13:21.613205", "stderr": "mkdir: cannot create directory '/data/postgresql/data': No such file or directory", "stdout": "Initializing database ... failed, see /var/lib/pgsql/initdb.log", "stdout_lines": ["Initializing database ... failed, see /var/lib/pgsql/initdb.log"], "warnings": []}`

This PR is easy and trying to fix this.
